### PR TITLE
Convert MultiContentsManager to AsyncContentsManager

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 26.3.1
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.10
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:

--- a/example/jupyter_notebook_config.py
+++ b/example/jupyter_notebook_config.py
@@ -4,7 +4,6 @@ from IPython.html.services.contents.filemanager import FileContentsManager
 
 from multicontents import MultiContentsManager
 
-
 c = get_config()  # noqa
 c.NotebookApp.nbserver_extensions = {"multicontents": True}
 

--- a/multicontents/__init__.py
+++ b/multicontents/__init__.py
@@ -1,6 +1,3 @@
 # flake8: noqa
-try:
-    import notebook.transutils
-except ImportError:
-    import jupyter_server.transutils
+import jupyter_server.transutils
 from multicontents.multicontents_manager import MultiContentsManager

--- a/multicontents/multi_versions_file_checkpoints.py
+++ b/multicontents/multi_versions_file_checkpoints.py
@@ -2,15 +2,10 @@ import os
 import datetime
 
 from jupyter_core.utils import ensure_dir_exists
+from jupyter_server.services.contents.filecheckpoints import AsyncGenericFileCheckpoints
 
 
-try:
-    from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoints
-except ImportError:
-    from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
-
-
-class MultiVersionsFileCheckpoints(GenericFileCheckpoints):
+class AsyncMultiVersionsFileCheckpoints(AsyncGenericFileCheckpoints):
     def checkpoint_path(self, checkpoint_id, path):
         """find the path to a checkpoint"""
         checkpoint_dir = self.get_checkpoints_path_for_file(path)
@@ -38,35 +33,35 @@ class MultiVersionsFileCheckpoints(GenericFileCheckpoints):
         checkpoint_id = str(saved_time.timestamp()).replace(".", "")
         return checkpoint_dir, checkpoint_id
 
-    def create_file_checkpoint(self, content, format, path):
+    async def create_file_checkpoint(self, content, format, path):
         checkpoint_dir, checkpoint_id = self.get_checkpoint_dir_and_id(
             path, create_missing=True
         )
         checkpoint_file_path = os.path.join(checkpoint_dir, checkpoint_id)
         self.log.debug("creating checkpoint for %s", path)
         with self.perm_to_403():
-            self._save_file(checkpoint_file_path, content, format=format)
-        return self.checkpoint_model(checkpoint_id, checkpoint_file_path)
+            await self._save_file(checkpoint_file_path, content, format=format)
+        return await self.checkpoint_model(checkpoint_id, checkpoint_file_path)
 
-    def create_notebook_checkpoint(self, nb, path):
+    async def create_notebook_checkpoint(self, nb, path):
         checkpoint_dir, checkpoint_id = self.get_checkpoint_dir_and_id(
             path, create_missing=True
         )
         checkpoint_file_path = os.path.join(checkpoint_dir, checkpoint_id)
         self.log.debug("creating checkpoint for %s", path)
         with self.perm_to_403():
-            self._save_notebook(checkpoint_file_path, nb)
-        return self.checkpoint_model(checkpoint_id, checkpoint_file_path)
+            await self._save_notebook(checkpoint_file_path, nb)
+        return await self.checkpoint_model(checkpoint_id, checkpoint_file_path)
 
-    def list_checkpoints(self, path):
+    async def list_checkpoints(self, path):
         checkpoint_dir = self.get_checkpoints_path_for_file(path)
         if not os.path.isdir(checkpoint_dir):
             return []
-        checkpoints = [
-            self.checkpoint_model(
+        checkpoints = []
+        for file_name in os.listdir(checkpoint_dir):
+            checkpoint = await self.checkpoint_model(
                 file_name,
                 os.path.join(self.get_checkpoints_path_for_file(path), file_name),
             )
-            for file_name in os.listdir(checkpoint_dir)
-        ]
+            checkpoints.append(checkpoint)
         return sorted(checkpoints, key=lambda c: -c["last_modified"].timestamp())

--- a/multicontents/multicontents_manager.py
+++ b/multicontents/multicontents_manager.py
@@ -3,16 +3,14 @@ import re
 import datetime
 import importlib
 
+from jupyter_core.utils import ensure_async
 from tornado.web import HTTPError
 from traitlets import Dict
 
-from multicontents.multi_versions_file_checkpoints import MultiVersionsFileCheckpoints
-
-try:
-    from jupyter_server.services.contents.manager import ContentsManager
-except ImportError:
-    from notebook.services.contents.manager import ContentsManager
-
+from jupyter_server.services.contents.manager import AsyncContentsManager
+from multicontents.multi_versions_file_checkpoints import (
+    AsyncMultiVersionsFileCheckpoints,
+)
 
 DUMMY_CREATED_DATE = datetime.datetime.fromtimestamp(86400)
 
@@ -74,11 +72,13 @@ class WrapperManager(object):
         actual_path = actual_path.strip("/")
         return os.path.join(self.proxy_path, actual_path).strip("/")
 
-    def get(self, path, *args, **kwargs):
-        result = self.manager.get(self.to_actual_path(path), *args, **kwargs)
+    async def get(self, path, *args, **kwargs):
+        result = await ensure_async(
+            self.manager.get(self.to_actual_path(path), *args, **kwargs)
+        )
         if result.get("path", None):
             result["path"] = self.to_proxy_path(result["path"])
-        if result.get("content", None) and self.dir_exists(path):
+        if result.get("content", None) and await self.dir_exists(path):
             result["content"] = [
                 dict(
                     list(model.items()) + [("path", self.to_proxy_path(model["path"]))]
@@ -87,28 +87,30 @@ class WrapperManager(object):
             ]
         return result
 
-    def save(self, model, path):
-        return self.manager.save(model, self.to_actual_path(path))
+    async def save(self, model, path):
+        return await ensure_async(self.manager.save(model, self.to_actual_path(path)))
 
-    def delete_file(self, path):
-        return self.manager.delete_file(self.to_actual_path(path))
+    async def delete_file(self, path):
+        return await ensure_async(self.manager.delete_file(self.to_actual_path(path)))
 
-    def file_exists(self, path=None):
-        return self.manager.file_exists(self.to_actual_path(path))
+    async def file_exists(self, path=None):
+        return await ensure_async(self.manager.file_exists(self.to_actual_path(path)))
 
-    def dir_exists(self, path):
-        return self.manager.dir_exists(self.to_actual_path(path))
+    async def dir_exists(self, path):
+        return await ensure_async(self.manager.dir_exists(self.to_actual_path(path)))
 
-    def is_hidden(self, path):
-        return self.manager.is_hidden(self.to_actual_path(path))
+    async def is_hidden(self, path):
+        return await ensure_async(self.manager.is_hidden(self.to_actual_path(path)))
 
-    def rename_file(self, old_path, new_path):
-        self.manager.rename_file(
-            self.to_actual_path(old_path), self.to_actual_path(new_path)
+    async def rename_file(self, old_path, new_path):
+        await ensure_async(
+            self.manager.rename_file(
+                self.to_actual_path(old_path), self.to_actual_path(new_path)
+            )
         )
 
 
-class MultiContentsManager(ContentsManager):
+class MultiContentsManager(AsyncContentsManager):
 
     managers = Dict(help="the path to manager_class settings").tag(config=True)
 
@@ -118,15 +120,11 @@ class MultiContentsManager(ContentsManager):
             WrapperManager(path.lstrip("/"), config["manager_class"], config["kwargs"])
             for path, config in self.managers.items()
         ]
-        # path are searched based on the depth, so that we will always match
-        # to the closest one first
         self._managers.sort(
             key=lambda manager: (
-                manager.proxy_path == "",  # non root matched first
-                -len(manager.proxy_path.split("/")),  # match deeper folder first
-                -len(
-                    manager.proxy_path.rsplit("/", 1)[-1]
-                ),  # match longest directory name first
+                manager.proxy_path == "",
+                -len(manager.proxy_path.split("/")),
+                -len(manager.proxy_path.rsplit("/", 1)[-1]),
             )
         )
 
@@ -136,15 +134,13 @@ class MultiContentsManager(ContentsManager):
                 return manager
         raise HTTPError(404, f"Manager not found for path: '{path}'")
 
-    def get(self, path, *args, **kwargs):
+    async def get(self, path, *args, **kwargs):
         try:
             manager = self.get_manager(path)
-            current = manager.get(path, *args, **kwargs)
-            is_dir = manager.dir_exists(path)
+            current = await manager.get(path, *args, **kwargs)
+            is_dir = await manager.dir_exists(path)
         except HTTPError as e:
-            # if root is not configured, we build a virtual directory to list all
-            # the defined path
-            if path == "/" or path == "":  # jupyterlab use "/", but classic use ""
+            if path == "/" or path == "":
                 current = build_base_model(
                     type_="directory",
                     path="/",
@@ -155,7 +151,6 @@ class MultiContentsManager(ContentsManager):
             else:
                 raise e
 
-        # add virtual directory
         if kwargs.get("content", None) and is_dir:
             extra = [
                 build_base_model(
@@ -167,11 +162,10 @@ class MultiContentsManager(ContentsManager):
             current["content"] += extra
         return current
 
-    def rename_file(self, old_path, new_path):
+    async def rename_file(self, old_path, new_path):
         old_manager = self.get_manager(old_path)
         new_manager = self.get_manager(new_path)
 
-        # avoid renaming on virtual folder
         if (
             old_manager.to_actual_path(old_path) == ""
             or new_manager.to_actual_path(new_path) == ""
@@ -179,36 +173,36 @@ class MultiContentsManager(ContentsManager):
             raise HTTPError(400, reason="You cannot rename the virtual directory")
 
         if old_manager == new_manager:
-            old_manager.rename_file(old_path, new_path)
+            await old_manager.rename_file(old_path, new_path)
         else:
-            model = old_manager.get(old_path)
-            new_manager.save(model, new_path)
-            if self.dir_exists(old_path):
-                for model in self.get(old_path)["content"]:
-                    self.rename_file(
+            model = await old_manager.get(old_path)
+            await new_manager.save(model, new_path)
+            if await self.dir_exists(old_path):
+                for model in (await self.get(old_path))["content"]:
+                    await self.rename_file(
                         os.path.join(old_path, model["name"]),
                         os.path.join(new_path, model["name"]),
                     )
-            old_manager.delete_file(old_path)
+            await old_manager.delete_file(old_path)
 
-    def save(self, model, path):
-        return self.get_manager(path).save(model, path)
+    async def save(self, model, path):
+        return await self.get_manager(path).save(model, path)
 
-    def delete_file(self, path):
-        return self.get_manager(path).delete_file(path)
+    async def delete_file(self, path):
+        return await self.get_manager(path).delete_file(path)
 
-    def file_exists(self, path=None):
-        return self.get_manager(path).file_exists(path)
+    async def file_exists(self, path=None):
+        return await self.get_manager(path).file_exists(path)
 
-    def dir_exists(self, path):
+    async def dir_exists(self, path):
         if path == "":
             return True
-        return self.get_manager(path).dir_exists(path)
+        return await self.get_manager(path).dir_exists(path)
 
-    def is_hidden(self, path):
+    async def is_hidden(self, path):
         if path == "":
             return False
-        return self.get_manager(path).is_hidden(path)
+        return await self.get_manager(path).is_hidden(path)
 
     def _checkpoints_class_default(self):
-        return MultiVersionsFileCheckpoints
+        return AsyncMultiVersionsFileCheckpoints

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -5,4 +5,5 @@ mock
 pre-commit>=1.0.0
 pytest
 pytest-cov
+pytest-asyncio
 requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,6 +70,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest==6.2.2
 pytest-cov==2.11.1
+pytest-asyncio==0.23.8
 python-dateutil==2.8.1
 pytz==2021.1
 PyYAML==5.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+asyncio_mode = auto

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,12 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md")) as fp:
     long_description = fp.read()
 
 setup(
     name="multicontents",
-    version="0.4.0",
+    version="0.5.0",
     description="providing contents from multiple sources in jupyter notebook",
     long_description_content_type="text/markdown",
     long_description=long_description,
@@ -20,8 +19,8 @@ setup(
     maintainer="Lydian Lee",
     maintainer_email="lydianly@gmail.com",
     packages=find_packages(),
-    install_requires=["notebook", "ipykernel"],
-    python_requires=">=3.6",
+    install_requires=["jupyter_server", "ipykernel"],
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -4,7 +4,6 @@ import socket
 import pytest
 import requests
 
-
 pid = None
 
 

--- a/tests/multi_versions_file_checkpoints_test.py
+++ b/tests/multi_versions_file_checkpoints_test.py
@@ -4,24 +4,26 @@ import json
 
 import pytest
 
-from multicontents.multi_versions_file_checkpoints import MultiVersionsFileCheckpoints
+from multicontents.multi_versions_file_checkpoints import (
+    AsyncMultiVersionsFileCheckpoints,
+)
 
 
-class TestMultiVersionsFileCheckpoints(object):
+class TestAsyncMultiVersionsFileCheckpoints(object):
     @pytest.fixture
     def root_dir(self, tmpdir):
         return str(tmpdir.mkdir("test"))
 
     @pytest.fixture
     def checkpoints(self, root_dir):
-        return MultiVersionsFileCheckpoints(
+        return AsyncMultiVersionsFileCheckpoints(
             root_dir=root_dir, checkpoint_dir=".checkpoints"
         )
 
-    def test_create_file_checkpoint(self, checkpoints):
+    async def test_create_file_checkpoint(self, checkpoints):
         content = "test content"
         path = "inside/folder/file.txt"
-        model = checkpoints.create_file_checkpoint(content, "text", path)
+        model = await checkpoints.create_file_checkpoint(content, "text", path)
 
         generated_check_point = os.path.join(
             checkpoints.root_dir,
@@ -34,10 +36,10 @@ class TestMultiVersionsFileCheckpoints(object):
             generated_content = fp.read()
         assert content == generated_content
 
-    def test_create_notebook_checkpoint(self, checkpoints):
+    async def test_create_notebook_checkpoint(self, checkpoints):
         content = {}
         path = "inside/folder/file.ipynb"
-        model = checkpoints.create_notebook_checkpoint(content, path)
+        model = await checkpoints.create_notebook_checkpoint(content, path)
 
         generated_check_point = os.path.join(
             checkpoints.root_dir,
@@ -50,26 +52,26 @@ class TestMultiVersionsFileCheckpoints(object):
             generated_content = fp.read()
         assert content == json.loads(generated_content)
 
-    def test_list_checkpoints__no_checkpoint(self, checkpoints):
-        assert checkpoints.list_checkpoints("not exists") == []
+    async def test_list_checkpoints__no_checkpoint(self, checkpoints):
+        assert await checkpoints.list_checkpoints("not exists") == []
 
-    def test_list_checkpoints_has_file_checkpoints(self, checkpoints):
-        v1 = checkpoints.create_file_checkpoint("v1", "text", "file.txt")
+    async def test_list_checkpoints_has_file_checkpoints(self, checkpoints):
+        v1 = await checkpoints.create_file_checkpoint("v1", "text", "file.txt")
         time.sleep(1)
-        v2 = checkpoints.create_file_checkpoint("v2", "text", "file.txt")
+        v2 = await checkpoints.create_file_checkpoint("v2", "text", "file.txt")
 
-        saved_checkpoints = checkpoints.list_checkpoints("file.txt")
+        saved_checkpoints = await checkpoints.list_checkpoints("file.txt")
         assert saved_checkpoints == [
             {"id": v2["id"], "last_modified": v2["last_modified"]},
             {"id": v1["id"], "last_modified": v1["last_modified"]},
         ]
 
-    def test_list_checkpoints_has_nb_checkpoints(self, checkpoints):
-        v1 = checkpoints.create_notebook_checkpoint({}, "notebook.ipynb")
+    async def test_list_checkpoints_has_nb_checkpoints(self, checkpoints):
+        v1 = await checkpoints.create_notebook_checkpoint({}, "notebook.ipynb")
         time.sleep(1)
-        v2 = checkpoints.create_notebook_checkpoint({}, "notebook.ipynb")
+        v2 = await checkpoints.create_notebook_checkpoint({}, "notebook.ipynb")
 
-        saved_checkpoints = checkpoints.list_checkpoints("notebook.ipynb")
+        saved_checkpoints = await checkpoints.list_checkpoints("notebook.ipynb")
         assert saved_checkpoints == [
             {"id": v2["id"], "last_modified": v2["last_modified"]},
             {"id": v1["id"], "last_modified": v1["last_modified"]},

--- a/tests/multicontents_manager_test.py
+++ b/tests/multicontents_manager_test.py
@@ -1,3 +1,5 @@
+import os
+
 import mock
 import pytest
 from tornado.web import HTTPError
@@ -96,15 +98,28 @@ class TestWrapperManager(object):
         manager = WrapperManager(proxy_path, DummyManager, {})
         assert manager.to_proxy_path(path) == expected_result
 
-    def test_get(self):
+    async def test_get(self):
         mock_get = mock.Mock(return_value={"content": [{"path": "foo/bar"}]})
         mock_dir_exists = mock.Mock(return_value=True)
         manager = WrapperManager(
             "proxy", DummyManager, {"get": mock_get, "dir_exists": mock_dir_exists}
         )
         with mock.patch.object(manager, "to_proxy_path") as mock_to_proxy:
-            result = manager.get("path")
+            result = await manager.get("path")
         assert result["content"] == [{"path": mock_to_proxy()}]
+
+    async def test_get_with_async_underlying_manager(self):
+        async def async_get(path, *args, **kwargs):
+            return {"content": [{"path": "foo/bar"}]}
+
+        async def async_dir_exists(path):
+            return True
+
+        manager = WrapperManager(
+            "proxy", DummyManager, {"get": async_get, "dir_exists": async_dir_exists}
+        )
+        result = await manager.get("proxy/somefile")
+        assert result["content"] == [{"path": "proxy/foo/bar"}]
 
     @pytest.fixture
     def wrapper_maanger(self):
@@ -112,37 +127,44 @@ class TestWrapperManager(object):
         with mock.patch.object(manager, "to_actual_path"):
             yield manager
 
-    def test_save(self, wrapper_maanger):
-        wrapper_maanger.save({}, "path")
+    async def test_save(self, wrapper_maanger):
+        await wrapper_maanger.save({}, "path")
         wrapper_maanger.manager.save.assert_called_once_with(
             {}, wrapper_maanger.to_actual_path.return_value
         )
         wrapper_maanger.to_actual_path.assert_called_once_with("path")
 
-    def test_delete_file(self, wrapper_maanger):
-        wrapper_maanger.delete_file("path")
+    async def test_delete_file(self, wrapper_maanger):
+        await wrapper_maanger.delete_file("path")
         wrapper_maanger.manager.delete_file.assert_called_once_with(
             wrapper_maanger.to_actual_path.return_value
         )
         wrapper_maanger.to_actual_path.assert_called_once_with("path")
 
-    def test_file_exists(self, wrapper_maanger):
-        wrapper_maanger.file_exists("path")
+    async def test_file_exists(self, wrapper_maanger):
+        await wrapper_maanger.file_exists("path")
         wrapper_maanger.manager.file_exists.assert_called_once_with(
             wrapper_maanger.to_actual_path.return_value
         )
         wrapper_maanger.to_actual_path.assert_called_once_with("path")
 
-    def test_dir_exists(self, wrapper_maanger):
-        wrapper_maanger.dir_exists("path")
+    async def test_dir_exists(self, wrapper_maanger):
+        await wrapper_maanger.dir_exists("path")
         wrapper_maanger.manager.dir_exists.assert_called_once_with(
             wrapper_maanger.to_actual_path.return_value
         )
         wrapper_maanger.to_actual_path.assert_called_once_with("path")
 
-    def test_rename_file(self, wrapper_maanger):
+    async def test_is_hidden(self, wrapper_maanger):
+        await wrapper_maanger.is_hidden("path")
+        wrapper_maanger.manager.is_hidden.assert_called_once_with(
+            wrapper_maanger.to_actual_path.return_value
+        )
+        wrapper_maanger.to_actual_path.assert_called_once_with("path")
+
+    async def test_rename_file(self, wrapper_maanger):
         wrapper_maanger.to_actual_path.side_effect = lambda path: f"patched-{path}"
-        wrapper_maanger.rename_file("old_path", "new_path")
+        await wrapper_maanger.rename_file("old_path", "new_path")
 
         wrapper_maanger.manager.rename_file.assert_called_once_with(
             "patched-old_path", "patched-new_path"
@@ -193,63 +215,87 @@ class TestMultiContentsManager(object):
         ]
 
     @pytest.mark.parametrize(
-        "path,expected_result", [("", ["abc", "def", "child"]), ("child", ["foo"])]
+        "path,expected_result",
+        [("", ["abc", "def", "child"]), ("child", ["child/foo"])],
     )
-    def test_get_with_manager_with_root(self, manager_with_root, path, expected_result):
-        manager_with_root._managers[1].dir_exists = mock.Mock(return_value=True)
-        manager_with_root._managers[1].get = mock.Mock(
+    async def test_get_with_manager_with_root(
+        self, manager_with_root, path, expected_result
+    ):
+        manager_with_root._managers[1].manager.dir_exists = mock.Mock(return_value=True)
+        manager_with_root._managers[1].manager.get = mock.Mock(
             return_value={"content": [{"path": "abc"}, {"path": "def"}]}
         )
-        manager_with_root._managers[0].get = mock.Mock(
+        manager_with_root._managers[0].manager.dir_exists = mock.Mock(return_value=True)
+        manager_with_root._managers[0].manager.get = mock.Mock(
             return_value={"content": [{"path": "foo"}]}
         )
-        result = manager_with_root.get(path, content=True)
+        result = await manager_with_root.get(path, content=True)
         assert [item["path"] for item in result["content"]] == expected_result
 
     @pytest.mark.parametrize(
         "path,expected_result",
-        [("/", ["other", "foo"]), ("foo", ["abc", "def"]), ("other", ["ghi"])],
+        [
+            ("/", ["other", "foo"]),
+            ("foo", ["foo/abc", "foo/def"]),
+            ("other", ["other/ghi"]),
+        ],
     )
-    def test_get_without_manager_with_root(
+    async def test_get_without_manager_with_root(
         self, manager_without_root, path, expected_result
     ):
-        manager_without_root._managers[1].get = mock.Mock(
+        manager_without_root._managers[1].manager.dir_exists = mock.Mock(
+            return_value=True
+        )
+        manager_without_root._managers[1].manager.get = mock.Mock(
             return_value={"content": [{"path": "abc"}, {"path": "def"}]}
         )
-        manager_without_root._managers[0].get = mock.Mock(
+        manager_without_root._managers[0].manager.dir_exists = mock.Mock(
+            return_value=True
+        )
+        manager_without_root._managers[0].manager.get = mock.Mock(
             return_value={"content": [{"path": "ghi"}]}
         )
-        result = manager_without_root.get(path, content=True)
+        result = await manager_without_root.get(path, content=True)
         assert [item["path"] for item in result["content"]] == expected_result
 
-    def test_rename_file_same_manager(self, manager_with_root):
-        manager_with_root._managers[0].rename_file = mock.Mock()
-        manager_with_root.rename_file("child/test1", "child/test2")
-        manager_with_root._managers[0].rename_file.assert_called_once_with(
-            "child/test1", "child/test2"
+    async def test_rename_file_same_manager(self, manager_with_root):
+        manager_with_root._managers[0].manager.rename_file = mock.Mock()
+        await manager_with_root.rename_file("child/test1", "child/test2")
+        manager_with_root._managers[0].manager.rename_file.assert_called_once_with(
+            "test1", "test2"
         )
 
     @pytest.mark.parametrize(
         "old_path,new_path", [("/foo", "something/new"), ("something", "/foo")]
     )
-    def test_rename_file_virtual_direcotry(
+    async def test_rename_file_virtual_direcotry(
         self, manager_without_root, old_path, new_path
     ):
         with pytest.raises(HTTPError):
-            manager_without_root.rename_file(old_path, new_path)
+            await manager_without_root.rename_file(old_path, new_path)
 
-    def test_rename_file_different_manager_file(self, manager_with_root):
-        manager_with_root._managers[0].get = mock.Mock()
-        manager_with_root._managers[0].delete_file = mock.Mock()
-        manager_with_root._managers[1].save = mock.Mock()
-        with mock.patch.object(manager_with_root, "dir_exists", return_value=False):
-            manager_with_root.rename_file("child/test1", "test2")
-        manager_with_root._managers[0].get.assert_called_once_with("child/test1")
-        manager_with_root._managers[1].save.assert_called_once_with(
-            manager_with_root._managers[0].get.return_value, "test2"
+    async def test_rename_file_different_manager_file(self, manager_with_root):
+        fake_model = {"path": "test1", "content": None, "type": "file"}
+        manager_with_root._managers[0].manager.get = mock.Mock(return_value=fake_model)
+        manager_with_root._managers[0].manager.dir_exists = mock.Mock(
+            return_value=False
         )
-        manager_with_root._managers[0].delete_file.assert_called_once_with(
-            "child/test1"
+        manager_with_root._managers[0].manager.delete_file = mock.Mock()
+        manager_with_root._managers[1].manager.save = mock.Mock()
+
+        async def fake_dir_exists(path):
+            return False
+
+        with mock.patch.object(
+            manager_with_root, "dir_exists", side_effect=fake_dir_exists
+        ):
+            await manager_with_root.rename_file("child/test1", "test2")
+        manager_with_root._managers[0].manager.get.assert_called_once_with("test1")
+        manager_with_root._managers[1].manager.save.assert_called_once_with(
+            fake_model, "test2"
+        )
+        manager_with_root._managers[0].manager.delete_file.assert_called_once_with(
+            "test1"
         )
 
     def get_fake_item(self, path):
@@ -261,7 +307,7 @@ class TestMultiContentsManager(object):
 
     @pytest.fixture
     def mock_dir_exists(self, manager_with_root):
-        def dir_exists(path):
+        async def dir_exists(path):
             return self.get_fake_item(path) is not None
 
         with mock.patch.object(manager_with_root, "dir_exists", side_effect=dir_exists):
@@ -269,22 +315,39 @@ class TestMultiContentsManager(object):
 
     @pytest.fixture
     def mock_get(self, manager_with_root):
-        def get(path):
+        async def get(path, **kwargs):
             obj = self.get_fake_item(path)
-            content = [{"name": key} for key in obj] if obj is not None else ""
+            content = (
+                [{"name": key, "path": os.path.join(path, key)} for key in obj]
+                if obj is not None
+                else ""
+            )
             return {"name": path.rsplit("/", 1)[-1], "path": path, "content": content}
 
         with mock.patch.object(manager_with_root, "get", side_effect=get):
-            manager_with_root._managers[1].get = mock.Mock(side_effect=get)
+            manager_with_root._managers[1].manager.dir_exists = mock.Mock(
+                side_effect=lambda path: self.get_fake_item(path) is not None
+            )
+            manager_with_root._managers[1].manager.get = mock.Mock(
+                side_effect=lambda path, **kwargs: {
+                    "name": path.rsplit("/", 1)[-1],
+                    "path": path,
+                    "content": (
+                        [{"name": key, "path": os.path.join(path, key)} for key in obj]
+                        if (obj := self.get_fake_item(path)) is not None
+                        else ""
+                    ),
+                }
+            )
             yield
 
-    def test_rename_file_different_manager_dir(
+    async def test_rename_file_different_manager_dir(
         self, manager_with_root, mock_dir_exists, mock_get
     ):
-        manager_with_root._managers[1].delete_file = mock.Mock()
-        manager_with_root._managers[0].save = mock.Mock()
+        manager_with_root._managers[1].manager.delete_file = mock.Mock()
+        manager_with_root._managers[0].manager.save = mock.Mock()
 
-        manager_with_root.rename_file("folder_1", "child/test_2")
+        await manager_with_root.rename_file("folder_1", "child/test_2")
 
         old_files = [
             "folder_1",
@@ -292,13 +355,18 @@ class TestMultiContentsManager(object):
             "folder_1/folder_3",
             "folder_1/folder_3/file_4",
         ]
-        manager_with_root._managers[1].get.assert_has_calls(
-            mock.call(f) for f in old_files
+        manager_with_root._managers[1].manager.get.assert_has_calls(
+            [mock.call(f) for f in old_files]
         )
-        manager_with_root._managers[0].save.assert_has_calls(
-            mock.call(mock.ANY, f.replace("folder_1", "child/test_2"))
-            for f in old_files
+        new_files = [
+            "test_2",
+            "test_2/file_2",
+            "test_2/folder_3",
+            "test_2/folder_3/file_4",
+        ]
+        manager_with_root._managers[0].manager.save.assert_has_calls(
+            [mock.call(mock.ANY, f) for f in new_files]
         )
-        manager_with_root._managers[1].delete_file.assert_has_calls(
+        manager_with_root._managers[1].manager.delete_file.assert_has_calls(
             [mock.call(f) for f in old_files], any_order=True
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py36
+envlist = py310
 
 [testenv]
-deps = -rrequirements-dev.txt
+deps = -rrequirements-dev-minimal.txt
 passenv = HOME SSH_AUTH_SOCK USER
-basepython=python3.6
+basepython=python3.10
 commands =
     pytest --cov=multicontents/ {posargs:tests}
     pre-commit install -f --install-hooks


### PR DESCRIPTION
## Why
It really should be async given that many of the underlying filesystems could be slow queries.  But really I just want it to work with [jupyter-mcp-server package](https://github.com/datalayer/jupyter-mcp-server) which only works with async contents managers.

## Specifics
- Migrate `MultiContentsManager` from synchronous `ContentsManager` to `AsyncContentsManager` from `jupyter_server`, enabling non-blocking file operations for async-capable storage backends
- Use `ensure_async` from `jupyter_core.utils` in `WrapperManager` so both sync and async underlying managers work transparently without configuration
- Replace `MultiVersionsFileCheckpoints` with `AsyncMultiVersionsFileCheckpoints` backed by `AsyncGenericFileCheckpoints`

**BREAKING CHANGE**: All `MultiContentsManager` public methods are now `async`. The `notebook` package fallback import has been removed — `jupyter_server` is now required.

## Test plan
- All unit tests passing
- Installed v0.5.0 candidate from this PR into a jupyter server and tested it working e2e